### PR TITLE
Add an option to prevent popstate listener

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,8 @@ export default class {
             isLoaded: false,
             isEntered: false,
             isUrl: false,
-            transitionContainer: null
+            transitionContainer: null,
+            popstateIgnore: false
         }
 
         Object.assign(this, this.defaults, options);
@@ -69,6 +70,10 @@ export default class {
     }
 
     checkState() {
+        if((typeof this.popstateIgnore === 'string') && window.location.href.indexOf(this.popstateIgnore) > -1) {
+            return
+        }
+
         this.reset();
         this.getStateOptions();
     }


### PR DESCRIPTION
Useful in many cases such as using Snipcart. Their cart triggers popstate events on window and having this option in modularload can prevent having unwanted transition while navigating the cart. Tested it with Snipcart by setting the option to `'/#'`, works fine. Didn't update the README